### PR TITLE
Add fallback/override serviceURL arg to Serverless.yml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adastradev/serverless-discovery-plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adastradev/serverless-discovery-plugin",
   "description": "Serverless plugin to register/de-register endpoints upon deploy and remove command hooks",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "author": "Andrew Regier <aregier@regiernet.com>",
   "contributors": [

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -146,7 +146,7 @@ export default class ServiceDiscoveryPlugin {
             // This data variable is looking for the service endpoint from CloudFormation
             // The alternative will look for a custom, freeform field under custom.discovery
             // in the Serverless.yml
-            ServiceURL: data['ServiceEndpoint'] || this.getConfig('serviceURL'), // tslint:disable-line
+            ServiceURL: data['ServiceEndpoint'] || JSON.stringify(this.getConfig('serviceURL')), // tslint:disable-line
             StageName: this.serverless.getProvider('aws').getStage(),
             Version: this.getConfig('version'),
             ExternalID: this.getConfig('externalID')

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -143,7 +143,10 @@ export default class ServiceDiscoveryPlugin {
 
         const service: ServiceApiModel = {
             ServiceName: this.serverless.service.getServiceName(),
-            ServiceURL: data['ServiceEndpoint'], // tslint:disable-line
+            // This data variable is looking for the service endpoint from CloudFormation
+            // The alternative will look for a custom, freeform field under custom.discovery
+            // in the Serverless.yml
+            ServiceURL: data['ServiceEndpoint'] || this.getConfig('serviceURL'), // tslint:disable-line
             StageName: this.serverless.getProvider('aws').getStage(),
             Version: this.getConfig('version'),
             ExternalID: this.getConfig('externalID')


### PR DESCRIPTION
One example use case is to override the serviceURL field with a Batch job name/ARN on AWS.